### PR TITLE
Enable the last element of the list to be used

### DIFF
--- a/src/DataGenerator/Extensions/RandomExtensions.cs
+++ b/src/DataGenerator/Extensions/RandomExtensions.cs
@@ -23,7 +23,7 @@ namespace DataGenerator.Extensions
             if (list == null || list.Count < 1)
                 return default(T);
 
-            var index = RandomGenerator.Current.Next(list.Count - 1);
+            var index = RandomGenerator.Current.Next(list.Count);
             return list[index];
         }
 


### PR DESCRIPTION
Using IEnumerable<string> as DataSource, and, frankly, any scenario that touches that line of code comes with side-effect of last element in the list not being used. The problem lies in the Random.Next(int max) method. If you see the docs to it, you'll notice, that the result will always be less than "max" argument, so subtracting 1 from the count of list doesn't save from IndexOutOfRangeException, but instead makes it impossible for the last element of the list to ever surface in the generated data.