### PR TITLE
Create IEnumerable instances from Generator where needed

### DIFF
--- a/src/DataGenerator/Generator.cs
+++ b/src/DataGenerator/Generator.cs
@@ -84,6 +84,58 @@ namespace DataGenerator
 
         /// <summary>
         /// Generates a random number of type <typeparamref name="T"/> with the properties set according to configuration.
+        ///
+        /// This will reduce memory consumption when creating and immediately processing generated objects.
+        /// </summary>
+        /// <typeparam name="T">The type to generate.</typeparam>
+        /// <returns>An enumerable of type <typeparamref name="T"/> with the properties set according to configuration.</returns>
+        public IEnumerable<T> Enumerable<T>()
+        {
+            return Enumerable<T>(2, 10);
+        }
+
+        /// <summary>
+        /// Generates a random number between <paramref name="min"/> and <paramref name="max"/> of type <typeparamref name="T"/> with
+        /// the properties set according to configuration.
+        ///
+        /// This will reduce memory consumption when creating and immediately processing generated objects.
+        /// </summary>
+        /// <typeparam name="T">The type to generate.</typeparam>
+        /// <returns>An enumberable of type <typeparamref name="T"/> with the properties set according to configuration.</returns>
+        public IEnumerable<T> Enumerable<T>(int min, int max)
+        {
+            var count = RandomGenerator.Current.Next(min, max);
+            return Enumerable<T>(count);
+        }
+
+        /// <summary>
+        /// Generates a <paramref name="count"/> of type <typeparamref name="T"/> with the properties set according to configuration.
+        ///
+        /// This will reduce memory consumption when creating and immediately processing generated objects.
+        /// </summary>
+        /// <typeparam name="T">The type to generate.</typeparam>
+        /// <returns>An enumerable of type <typeparamref name="T"/> with the properties set according to configuration.</returns>
+        public IEnumerable<T> Enumerable<T>(int count)
+        {
+            var type = typeof(T);
+            var classMapping = GetMapping(type);
+
+            // generate at least one
+            count = Math.Max(1, count);
+
+            for (var i = 0; i < count; i++)
+            {
+                var instance = CreateInstance<T>(classMapping);
+
+                GenerateInstance(classMapping, instance);
+
+                yield return instance;
+            }
+        }
+
+
+        /// <summary>
+        /// Generates a random number of type <typeparamref name="T"/> with the properties set according to configuration.
         /// </summary>
         /// <typeparam name="T">The type to generate.</typeparam>
         /// <returns>A list of type <typeparamref name="T"/> with the properties set according to configuration.</returns>

--- a/test/DataGenerator.Tests/GeneratorTest.cs
+++ b/test/DataGenerator.Tests/GeneratorTest.cs
@@ -262,5 +262,43 @@ namespace DataGenerator.Tests
             memberMapping.Should().NotBeNull();
             memberMapping.DataSource.Should().BeOfType<LoremIpsumSource>();
         }
+
+        [Fact]
+        public void GenerateEnumerable()
+        {
+            var generator = Generator.Create(c => c
+                .ExcludeName("xunit")
+                .Entity<User>(e =>
+                {
+                    e.AutoMap();
+
+                    // First name will be a guid to make sure we're not creating duplicates
+                    e.Property(p => p.FirstName).DataSource<GuidSource>();
+                    e.Property(p => p.LastName).DataSource<LastNameSource>();
+                    e.Property(p => p.Address1).DataSource<StreetSource>();
+                    e.Property(p => p.City).DataSource<CitySource>();
+                    e.Property(p => p.State).DataSource<StateSource>();
+                    e.Property(p => p.Zip).DataSource<PostalCodeSource>();
+
+                    e.Property(p => p.Note).DataSource<LoremIpsumSource>();
+                    e.Property(p => p.Password).DataSource<PasswordSource>();
+                })
+            );
+
+            var count = 50;
+
+            // Fetch an enumerable of users with GUID names
+            var users = generator.Enumerable<User>(count);
+
+            // Ensure it has the requested length
+            users.Should().HaveCount(count);
+
+            // Fetch all the unique names used in the enumerable
+            var uniqueUserNames = users.Select(u => u.FirstName).Distinct();
+
+            // Ensure every user has a unique name and the enumerable isn't just
+            // returning the same user over and over.
+            uniqueUserNames.Should().HaveCount(count);
+        }
     }
 }


### PR DESCRIPTION
Whilst trying to create very large test data sets which were generated and then immediately written elsewhere I hit a rather insane amount of memory when using `Generator.List`. I did write an extension method to create an IEnumerable that just used the `Generator.Single` method but obviously this would be more efficient if part of the actual Generator class itself, so I created the `Generator.Enumerable` method as below.

I debated updating the `Generator.List` method to just do `Enumerable<T>(count).ToList()` but didn't want to mess about too much with your existing source.

I've also written an incredibly basic test just to make sure it brings out the correct number of objects and they are actually distinct.

Cheers for the library either way, been incredibly helpful.